### PR TITLE
FI-1285: Add validator app

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ This is a template repository for an
 - Run `docker-compose run inferno bundle exec rake db:migrate` to set up the
   database.
 - Run `docker-compose up` in this repo.
-- Navigate to `http://localhost:4567`. Your test suite will be available.
+- Navigate to `http://localhost` to access Inferno, where your test suite will
+be available. To access the FHIR resource validator, navigate to 
+'http://localhost/validator'.
 
 ## Distributing tests
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ This is a template repository for an
   database.
 - Run `docker-compose up` in this repo.
 - Navigate to `http://localhost` to access Inferno, where your test suite will
-be available. To access the FHIR resource validator, navigate to 
-'http://localhost/validator'.
+be available. To access the FHIR resource validator, navigate to `http://localhost/validator`.
 
 ## Distributing tests
 

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -1,0 +1,101 @@
+# this sets the user nginx will run as,
+#and the number of worker processes
+user nobody nogroup;
+worker_processes  2;
+#user www-data;
+#worker_processes auto;
+
+# setup where nginx will log errors to
+# and where the nginx process id resides
+error_log  /var/log/nginx/error.log;
+pid        /var/run/nginx.pid;
+
+events {
+  worker_connections  1024;
+  # set to on if you have more than 1 worker_processes
+  accept_mutex on;
+}
+
+http {
+  include       /etc/nginx/mime.types;
+
+  default_type application/octet-stream;
+  access_log /tmp/nginx.access.log combined;
+
+  # use the kernel sendfile
+  # sendfile        on;  # this causes over-caching because modified timestamps lost in VM
+  # prepend http headers before sendfile()
+  tcp_nopush     on;
+
+  keepalive_timeout  600;
+  tcp_nodelay        on;
+
+  gzip  on;
+  gzip_vary on;
+  gzip_min_length 500;
+
+  gzip_disable "MSIE [1-6]\.(?!.*SV1)";
+  gzip_types text/plain text/xml text/css
+     text/comma-separated-values
+     text/javascript application/x-javascript
+     application/atom+xml image/x-icon;
+
+  # configure the virtual host
+  server {
+    # replace with your domain name
+    # server_name inferno-server;
+
+    # port to listen for requests on
+    listen 80;
+
+    # maximum accepted body size of client request
+    client_max_body_size 4G;
+    # the server will close connections after this time
+    keepalive_timeout 600;
+
+    location / {
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Port $server_port;
+      proxy_redirect off;
+      proxy_set_header Connection '';
+      proxy_http_version 1.1;
+      chunked_transfer_encoding off;
+      proxy_buffering off;
+      proxy_cache off;
+
+      proxy_pass http://inferno:4567;
+    }
+
+    location /validator {
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Port $server_port;
+      proxy_redirect off;
+      proxy_set_header Connection '';
+      proxy_http_version 1.1;
+      chunked_transfer_encoding off;
+      proxy_buffering off;
+      proxy_cache off;
+
+      proxy_pass http://fhir_validator_app;
+    }
+
+    location /validatorapi/ {
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Port $server_port;
+      proxy_redirect off;
+      proxy_set_header Connection '';
+      proxy_http_version 1.1;
+      chunked_transfer_encoding off;
+      proxy_buffering off;
+      proxy_cache off;
+
+      proxy_pass http://validator_service:4567/;
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
       context: ./
     volumes:
       - ./data:/opt/inferno/data
-    ports:
-      - "4567:4567"
     depends_on:
       - validator_service
   validator_service:
@@ -14,6 +12,22 @@ services:
     # Update this path to match your directory structure
     volumes:
       - ./lib/inferno_template/igs:/home/igs
+  fhir_validator_app:
+    image: infernocommunity/fhir-validator-app
+    depends_on:
+      - validator_service
+    environment:
+      EXTERNAL_VALIDATOR_URL: http://localhost/validatorapi
+      VALIDATOR_BASE_PATH: /validator
+  nginx:
+    image: nginx
+    volumes:
+      - ./config/nginx.conf:/etc/nginx/nginx.conf
+    ports:
+      - "80:80"
+    command: [nginx, '-g', 'daemon off;']
+    depends_on: 
+      - fhir_validator_app
   redis:
     image: redis
     volumes:


### PR DESCRIPTION
Adding nginx.conf file to Config folder, altered the docker-compose.yml, and updated the README to reflect that the validator app can now be accessed from within the template repo.